### PR TITLE
Added gitter chat link to the bottom of README.md (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ DAV (Decentralized Autonomous Vehicles) is a non-profit foundation working to bu
 One of the first projects being built by the DAV Foundation is a decentralized ride hailing app. This app connects drivers and passengers directly to each other. The repository you are looking at is the API that drives this ride hailing app for both passengers and drivers.
 
 [![license](https://img.shields.io/github/license/DAVFoundation/ride-hailing-api.svg?style=flat-square)](https://github.com/DAVFoundation/ride-hailing-api/blob/master/LICENSE)
+
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/DAVFoundation/DAV-Contributors)


### PR DESCRIPTION
Per the provided instructions, I added a gitter chat link to the bottom of README (#7). 

The content of the link was supplied by DAVFoundation. I then copied that content and pasted to desired location of the README.md file.